### PR TITLE
Feat: Use Phrase CLI v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
     - uses: ./
       with:
         version: 2.0.12
-    - run: which phraseapp
+    - run: which phrase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
     - run: npm test
     - uses: ./
       with:
-        version: 1.16.0
+        version: 2.0.12
     - run: which phraseapp

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     </a>
 </p>
 
-This action sets phraseapp command line tool for API Management
+This action sets [Phrase](https://phrase.com/) command line tool for API Management
 
 # Usage
 
@@ -15,9 +15,9 @@ See [action.yml](action.yml)
 ```yaml
 steps:
 - uses: actions/checkout@v1
-- uses: winify-ag/setup-phraseapp@v1
+- uses: winify-ag/setup-phraseapp@v2
   with:
-    version: 1.16.0
+    version: 2.0.12
 - run: phraseapp pull
 - run: phraseapp push --wait
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Setup Phrase CLI v2'
 description: 'Setup Phrase command line tool'
 inputs:
   version:
-    description: 'phrase/phraseapp-cli version'
+    description: 'phrase/phrase-cli version'
     required: true
 branding:
   icon: 'globe'

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Setup Phraseapp CLI'
-description: 'Setup Phraseapp command line tool'
+name: 'Setup Phrase CLI v2'
+description: 'Setup Phrase command line tool'
 inputs:
   version:
-    description: 'phrase/phraseapp-client version'
+    description: 'phrase/phraseapp-cli version'
     required: true
 branding:
   icon: 'globe'

--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ const archMapper = {
 
 async function run() {
   try {
-    const phraseapp = 'phraseapp'
+    const phrase = 'phrase'
     const osPlat = os.platform();
     const osArch = os.arch();
     const version = core.getInput('version');
-    const cacheToolPath = tc.find(phraseapp, version)
+    const cacheToolPath = tc.find(phrase, version)
 
     if (cacheToolPath && cacheToolPath !== '') {
       core.addPath(cacheToolPath);
@@ -28,17 +28,17 @@ async function run() {
     }
 
     const fileName = osPlat === 'win32'
-      ? `phraseapp_${osMapper[osPlat]}_${archMapper[osArch]}.exe`
-      : `phraseapp_${osMapper[osPlat]}_${archMapper[osArch]}`
+      ? `phrase_${osMapper[osPlat]}_${archMapper[osArch]}.exe`
+      : `phrase_${osMapper[osPlat]}_${archMapper[osArch]}`
 
-    const downloadUrl = 'https://github.com/phrase/phraseapp-client/releases/download/' + version + '/' + fileName;
+    const downloadUrl = 'https://github.com/phrase/phraseapp-cli/releases/download/' + version + '/' + fileName;
     const downloadPath = await tc.downloadTool(downloadUrl);
-    const toolPath = await tc.cacheFile(downloadPath, phraseapp, phraseapp, version, osArch);
+    const toolPath = await tc.cacheFile(downloadPath, phrase, phrase, version, osArch);
 
     core.addPath(toolPath);
 
     if (osPlat !== 'win32') {
-      cp.exec(`chmod +x ${toolPath}/${phraseapp}`)
+      cp.exec(`chmod +x ${toolPath}/${phrase}`)
     }
   } catch (error) {
     core.setFailed(error);

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ async function run() {
       ? `phrase_${osMapper[osPlat]}_${archMapper[osArch]}.exe`
       : `phrase_${osMapper[osPlat]}_${archMapper[osArch]}`
 
-    const downloadUrl = 'https://github.com/phrase/phraseapp-cli/releases/download/' + version + '/' + fileName;
+    const downloadUrl = 'https://github.com/phrase/phrase-cli/releases/download/' + version + '/' + fileName;
     const downloadPath = await tc.downloadTool(downloadUrl);
     const toolPath = await tc.cacheFile(downloadPath, phrase, phrase, version, osArch);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-phraseapp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-phraseapp",
-  "version": "1.0.0",
-  "description": "Setup Phraseapp command line tool",
+  "version": "2.0.0",
+  "description": "Setup the Phrase CLI v2 command line tool",
   "main": "index.js",
   "scripts": {
     "lint": "eslint index.js",
@@ -14,10 +14,12 @@
   "keywords": [
     "GitHub",
     "Actions",
-    "Phraseapp"
+    "Phraseapp",
+    "Phrase"
   ],
   "contributors": [
-    "Andrew Luca <thendrluca@gmail.com> (https://iamandrewluca.com)"
+    "Andrew Luca <thendrluca@gmail.com> (https://iamandrewluca.com)",
+    "Igor Araujo <contributor@araujoigor.com> (https://araujoigor.com)"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
First of all, thanks for the Phraseapp action :)

I have no idea if the Phraseapp CLI v1 will be discontinued but given that they put out the V2, I think it would be a good idea to support it.

The strategy is to simply use the Phrase CLI v2 repository to fetch the releases instead of using the v1. Then we bump this package version to `2.x`, to convey the information that this is a breaking change.

If you prefer to keep this tool only responsible for PhraseApp CLI v1, I can also add an action to the market place specifically to handle the v2.