### PR TITLE
Update README to add phrase cli command changes  v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ steps:
 - uses: winify-ag/setup-phraseapp@v2
   with:
     version: 2.0.12
-- run: phraseapp pull
-- run: phraseapp push --wait
+- run: phrase pull
+- run: phrase push --wait
 ```
+
+> If you ware using version previous version (1.16.0), you should use the `phraseapp` command instead of `phrase`
 
 
 # License


### PR DESCRIPTION
PhraseApp v2 doesn't use `phraseapp` cli command anymore. This updates the docs to follow this change.